### PR TITLE
Use a regular expression for matching pullspec versions

### DIFF
--- a/ci-operator/config/openshift/file-integrity-operator/openshift-file-integrity-operator-master.yaml
+++ b/ci-operator/config/openshift/file-integrity-operator/openshift-file-integrity-operator-master.yaml
@@ -21,7 +21,7 @@ operator:
     context_dir: .
     dockerfile_path: bundle.Dockerfile
   substitutions:
-  - pullspec: quay.io/file-integrity-operator/file-integrity-operator:0.1.30
+  - pullspec: "quay.io/file-integrity-operator/file-integrity-operator:\d+.\d+.\d+"
     with: pipeline:file-integrity-operator
 promotion:
   name: "4.12"


### PR DESCRIPTION
This makes it so that we can reference the operator version in the
bundle with a regular expression, instead of a specific version string
(e.g., 0.1.30).

This is an attempt to workaround issues where the upgrade jobs fails
with release PRs [0] since the bundle contains a new version number that
doesn't get substituted, causing the new version to get deployed,
instead of the version built for CI.

[0] https://github.com/openshift/file-integrity-operator/pull/289
