### PR TITLE
Break apart Compliance Operator CI jobs

### DIFF
--- a/ci-operator/config/ComplianceAsCode/compliance-operator/ComplianceAsCode-compliance-operator-master.yaml
+++ b/ci-operator/config/ComplianceAsCode/compliance-operator/ComplianceAsCode-compliance-operator-master.yaml
@@ -58,13 +58,32 @@ tests:
   commands: make test-unit
   container:
     from: src
-- as: e2e-aws
+- as: e2e-aws-parallel
   steps:
     cluster_profile: aws
     test:
     - as: test
       cli: latest
-      commands: make e2e
+      commands: make e2e-parallel
+      dependencies:
+      - env: IMAGE_FROM_CI
+        name: compliance-operator
+      - env: CONTENT_IMAGE_FROM_CI
+        name: testcontent
+      - env: OPENSCAP_IMAGE_FROM_CI
+        name: testopenscap
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+    workflow: ipi-aws
+- as: e2e-aws-serial
+  steps:
+    cluster_profile: aws
+    test:
+    - as: test
+      cli: latest
+      commands: make e2e-serial
       dependencies:
       - env: IMAGE_FROM_CI
         name: compliance-operator


### PR DESCRIPTION
Run the concurrent and serial tests on separate clusters, allowing for
faster CI reporting.
