### PR TITLE
Update SPO CI to use RHEL 9 base images with OpenShift 4.13

### DIFF
--- a/ci-operator/config/openshift/security-profiles-operator/openshift-security-profiles-operator-main.yaml
+++ b/ci-operator/config/openshift/security-profiles-operator/openshift-security-profiles-operator-main.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: golang-1.18
+    tag: rhel-9-release-golang-1.19-openshift-4.13
 canonical_go_repository: sigs.k8s.io/security-profiles-operator
 images:
 - dockerfile_path: Dockerfile.ubi


### PR DESCRIPTION
We need to start testing SPO using RHEL9 and this commit lays down the
configuration so we can start flushing out those issues.
