### PR TITLE
Update FIO pullspec for 1.3.1

### DIFF
--- a/ci-operator/config/openshift/file-integrity-operator/openshift-file-integrity-operator-master.yaml
+++ b/ci-operator/config/openshift/file-integrity-operator/openshift-file-integrity-operator-master.yaml
@@ -21,7 +21,7 @@ operator:
     context_dir: .
     dockerfile_path: bundle.Dockerfile
   substitutions:
-  - pullspec: quay.io/file-integrity-operator/file-integrity-operator:1.3.0
+  - pullspec: quay.io/file-integrity-operator/file-integrity-operator:1.3.1
     with: pipeline:file-integrity-operator
 promotion:
   name: "4.14"
@@ -100,7 +100,7 @@ tests:
     env:
       OO_CHANNEL: alpha
       OO_INSTALL_NAMESPACE: file-integrity
-      OO_LATEST_CSV: file-integrity-operator.v1.3.0
+      OO_LATEST_CSV: file-integrity-operator.v1.3.1
       OO_PACKAGE: file-integrity-operator
       OO_TARGET_NAMESPACES: '!install'
     test:


### PR DESCRIPTION
We're in the process of releasing FIO 1.3.1 and need to update the pull
spec to get the CI tests to pass with the new version.
